### PR TITLE
[KLC-1270] Change extension klever chain name to klever blockchain

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
-# KleverChain IDE for Visual Studio Code
+# Klever Blockchain IDE for Visual Studio Code
 
 <!-- ![Build Status](https://github.com/klever-io/kvm-ide-vscode/actions/workflows/build.yml/badge.svg) -->
 
 ## What is it?
 
-**KleverChain IDE** is an extension for Visual Studio Code that offers development support for KleverChain Smart Contracts written in Rust.
+**Klever Blockchain IDE** is an extension for Visual Studio Code that offers development support for Klever Blockchain Smart Contracts written in Rust.
 
 ## Main features
 
@@ -15,7 +15,7 @@
 
 ## How to get it
 
-KleverChain IDE can be installed from the Visual Studio Code Marketplace.
+Klever Blockchain IDE can be installed from the Visual Studio Code Marketplace.
 
 ## Requirements and dependencies
 
@@ -27,7 +27,7 @@ KleverChain IDE can be installed from the Visual Studio Code Marketplace.
 
 ### Other dependencies
 
-The main required dependency is the `RUST` buildchain, which is essential for building and managing your smart contract projects. For the KleverChain IDE, it is required to have the RUST buildchain installed on the **nightly** version. The nightly version includes the latest features and improvements that are necessary for developing KleverChain Smart Contracts.
+The main required dependency is the `RUST` buildchain, which is essential for building and managing your smart contract projects. For the Klever Blockchain IDE, it is required to have the RUST buildchain installed on the **nightly** version. The nightly version includes the latest features and improvements that are necessary for developing Klever Blockchain Smart Contracts.
 
 #### Installing the RUST buildchain
 
@@ -54,14 +54,14 @@ To install the RUST buildchain and set it up on the nightly version, follow thes
 
 #### Why the nightly version?
 
-Using the nightly version of Rust allows access to the most current Rust features and optimizations. Some features required by KleverChain Smart Contracts are only available in the nightly Rust channel. It is crucial for developers to be on this version to ensure compatibility and leverage the latest advancements in the Rust ecosystem.
+Using the nightly version of Rust allows access to the most current Rust features and optimizations. Some features required by Klever Blockchain Smart Contracts are only available in the nightly Rust channel. It is crucial for developers to be on this version to ensure compatibility and leverage the latest advancements in the Rust ecosystem.
 
 If you experience any issues during the installation or while setting Rust to the nightly version, please let us know [on Github](https://github.com/klever-io/kvm-ide-vscode/issues), on [Slack](https://join.slack.com/t/klever-blockchain/shared_invite/zt-1z69ikw0g-dXtRY7eGTnyRllsCV_YGOw), or [on the Forum](https://forum.klever.org/c/kleverchain/developers).
 
 
 ### [ksc](https://github.com/klever-io/klever-vm-sdk-rs)
 
-**ksc** is the backend of the Visual Studio Code extension. **ksc** is **required** by the KleverChain IDE. In order to install it, please follow [these steps](https://docs.klever.org). The extension, via `ksc`, will automatically download its external dependencies, so you do not have to worry much about setting up the development environment. These automatically installed dependencies include:
+**ksc** is the backend of the Visual Studio Code extension. **ksc** is **required** by the Klever Blockchain IDE. In order to install it, please follow [these steps](https://docs.klever.org). The extension, via `ksc`, will automatically download its external dependencies, so you do not have to worry much about setting up the development environment. These automatically installed dependencies include:
 
 * `Klever Operator` buildchain
 * `VM Tools` (e.g. tests / scenarios framework)
@@ -79,9 +79,9 @@ This extension contributes the following commands (`Ctrl+Shift+P`):
 * `runScenarios`
 
 
-## Configuring VSCode Settings for KleverChain IDE
+## Configuring VSCode Settings for Klever Blockchain IDE
 
-To tailor the KleverChain IDE extension to your development needs, you can configure several settings within your VSCode user settings. These settings allow you to specify paths to essential tools and resources, set the default KleverNode URL, and more. Below are the available settings along with their default values:
+To tailor the Klever Blockchain IDE extension to your development needs, you can configure several settings within your VSCode user settings. These settings allow you to specify paths to essential tools and resources, set the default KleverNode URL, and more. Below are the available settings along with their default values:
 
 ### Available Settings
 
@@ -94,7 +94,7 @@ To tailor the KleverChain IDE extension to your development needs, you can confi
 - `kleverchain.keyFile`: Defines the path to your wallet key file. This file is necessary for signing transactions and deploying contracts.
   - **Default**: `~/klever-sdk/walletKey.pem`
 
-- `kleverchain.address`: Your wallet address. This is used within the IDE to identify you and interact with the KleverChain network.
+- `kleverchain.address`: Your wallet address. This is used within the IDE to identify you and interact with the Klever Blockchain network.
   - **Default**: `""` (empty string, meaning you need to set this to your wallet address)
 
 ### How to Configure
@@ -103,10 +103,10 @@ To customize these settings for your development environment, follow these steps
 
 1. Open VSCode.
 2. Go to `File > Preferences > Settings` (or `Code > Preferences > Settings` on Mac).
-3. In the search bar at the top, type `kleverchain` to filter out the settings related to the KleverChain IDE.
+3. In the search bar at the top, type `kleverchain` to filter out the settings related to the Klever Blockchain IDE.
 4. You will see the settings listed above. Click on the edit icon next to each setting you wish to change and enter your desired value.
 
-By configuring these settings, you can ensure that the KleverChain IDE extension works seamlessly with your development setup and preferences. If you need further assistance or have suggestions for additional settings, please reach out to us [on Github](https://github.com/klever-io/kvm-ide-vscode/issues), on [Slack](https://join.slack.com/t/klever-blockchain/shared_invite/zt-1z69ikw0g-dXtRY7eGTnyRllsCV_YGOw), or [on the Forum](https://forum.klever.org/c/kleverchain/developers).
+By configuring these settings, you can ensure that the Klever Blockchain IDE extension works seamlessly with your development setup and preferences. If you need further assistance or have suggestions for additional settings, please reach out to us [on Github](https://github.com/klever-io/kvm-ide-vscode/issues), on [Slack](https://join.slack.com/t/klever-blockchain/shared_invite/zt-1z69ikw0g-dXtRY7eGTnyRllsCV_YGOw), or [on the Forum](https://forum.klever.org/c/kleverchain/developers).
 
 
 <!-- ## Installing the rust debugger pretty printer script
@@ -115,7 +115,7 @@ The rust debugger pretty printer script for LLDB allows proper viewing of manage
 
 Prerequisites: First, make sure that the [CodeLLDB](https://github.com/vadimcn/vscode-lldb) extension is installed. This can be done directly from Visual Studio Code extensions menu.
 
-Then, from Visual Studio Code open the command menu via `Ctrl+Shift+P` and run `KleverChain: Install the rust debugger pretty printer script`. If this option isn't present, make sure you have the latest version of the `KleverChain` Visual Studio Code extension.
+Then, from Visual Studio Code open the command menu via `Ctrl+Shift+P` and run `kleverchain: Install the rust debugger pretty printer script`. If this option isn't present, make sure you have the latest version of the `Klever Blockchain` Visual Studio Code extension.
 
 You will be prompted for the repository, branch and path for the pretty printer script. Simply leave the options blank in order to install the latest version of the script from mx-sdk-rs. -->
 

--- a/README.md
+++ b/README.md
@@ -119,6 +119,15 @@ Then, from Visual Studio Code open the command menu via `Ctrl+Shift+P` and run `
 
 You will be prompted for the repository, branch and path for the pretty printer script. Simply leave the options blank in order to install the latest version of the script from mx-sdk-rs. -->
 
+## Useful Links
+
+- [Klever Blockchain](https://klever.org/)
+- [Klever Blockchain Forum](https://forum.klever.org/c/kleverchain/developers)
+- [Klever Blockchain Documentation](https://docs.klever.org/welcome-to-the-Klever-Blockchain-documentation-website)
+- [Klever Blockchain IDE on Github](https://github.com/klever-io/kvm-ide-vscode/issues)
+- [Klever Blockchain IDE on Visual Studio Code Marketplace](https://marketplace.visualstudio.com/items?itemName=Klever-org.vscode-kvm-ide)
+- [Klever Wallet](https://klever.io/)
+
 ## Contributors
 
 ### How to publish an update of the extension

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ To install the RUST buildchain and set it up on the nightly version, follow thes
 
 Using the nightly version of Rust allows access to the most current Rust features and optimizations. Some features required by Klever Blockchain Smart Contracts are only available in the nightly Rust channel. It is crucial for developers to be on this version to ensure compatibility and leverage the latest advancements in the Rust ecosystem.
 
-If you experience any issues during the installation or while setting Rust to the nightly version, please let us know [on Github](https://github.com/klever-io/kvm-ide-vscode/issues), on [Slack](https://join.slack.com/t/klever-blockchain/shared_invite/zt-1z69ikw0g-dXtRY7eGTnyRllsCV_YGOw), or [on the Forum](https://forum.klever.org/c/kleverchain/developers).
+If you experience any issues during the installation or while setting Rust to the nightly version, please let us know [on Github](https://github.com/klever-io/kvm-ide-vscode/issues), or [on the Forum](https://forum.klever.org/c/kleverchain/developers).
 
 
 ### [ksc](https://github.com/klever-io/klever-vm-sdk-rs)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "vscode-kvm-ide",
-    "version": "1.0.6",
+    "version": "1.0.9",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "vscode-kvm-ide",
-            "version": "1.0.6",
+            "version": "1.0.9",
             "dependencies": {
                 "node-fetch": "^3.3.2"
             },
@@ -860,6 +860,7 @@
             "version": "1.9.0",
             "resolved": "https://registry.npmjs.org/acorn-import-assertions/-/acorn-import-assertions-1.9.0.tgz",
             "integrity": "sha512-cmMwop9x+8KFhxvKrKfPYmN6/pKTYYHBqLa0DfvVZcKMJWNyWLnaqND7dx/qn66R7ewM1UX5XMaDVP5wlVTaVA==",
+            "deprecated": "package has been renamed to acorn-import-attributes",
             "dev": true,
             "peerDependencies": {
                 "acorn": "^8"

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
     "name": "vscode-kvm-ide",
-    "displayName": "KleverChain IDE",
-    "description": "KleverChain IDE for developing Smart Contracts",
-    "version": "1.0.8",
+    "displayName": "Klever Blockchain IDE",
+    "description": "Klever Blockchain IDE for developing Smart Contracts",
+    "version": "1.0.9",
     "publisher": "klever-org",
     "repository": {
         "type": "git",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -12,7 +12,7 @@ import path = require("path");
 import fs = require("fs");
 
 export async function activate(context: vscode.ExtensionContext) {
-    Feedback.debug({ message: "KleverChain extension activated." });
+    Feedback.debug({ message: "Klever Blockchain extension activated." });
 
     Root.ExtensionContext = context;
 
@@ -65,7 +65,7 @@ export async function activate(context: vscode.ExtensionContext) {
 }
 
 export function deactivate() {
-    Feedback.debug({ message: "KleverChain extension deactivated." });
+    Feedback.debug({ message: "Klever Blockchain extension deactivated." });
 }
 
 async function setupWorkspace() {

--- a/src/feedback.ts
+++ b/src/feedback.ts
@@ -44,7 +44,7 @@ export class Feedback {
         if (options.display) {
             const message = `${withoutEndingPeriod(
                 options.message
-            )}. To see more details, pick "kleverchain" in vscode's "Output" panels.`;
+            )}. To see more details, pick "Klever Blockchain" in vscode's "Output" panels.`;
             const messageOptions: vscode.MessageOptions = {};
             await vscode.window.showErrorMessage(message, messageOptions, "Got it!");
         }
@@ -56,7 +56,7 @@ export class Feedback {
     }
 
     private static getChannel(): vscode.OutputChannel {
-        const channelName = `KleverChain`;
+        const channelName = `Klever Blockchain`;
 
         if (!this.outputChannels[channelName]) {
             this.outputChannels[channelName] = vscode.window.createOutputChannel(channelName);

--- a/src/presenter.ts
+++ b/src/presenter.ts
@@ -33,7 +33,7 @@ export async function askContractName() {
 
 export async function askInstallKsc(requiredVersion: Version): Promise<boolean> {
     let answer =
-        await askYesNo(`KleverChain IDE requires ksc ${requiredVersion}, which isn't available in your environment.
+        await askYesNo(`Klever Blockchain IDE requires ksc ${requiredVersion}, which isn't available in your environment.
 Do you agree to install it?`);
     return answer;
 }
@@ -58,7 +58,7 @@ export async function askKscVersion(defaultVersion: Version): Promise<Version> {
 
 export async function askInstallKoperator(requiredVersion: Version): Promise<boolean> {
     let answer =
-        await askYesNo(`KleverChain IDE requires koperator ${requiredVersion}, which isn't available in your environment.
+        await askYesNo(`Klever Blockchain IDE requires koperator ${requiredVersion}, which isn't available in your environment.
     Do you agree to install it?`);
     return answer;
 }


### PR DESCRIPTION
This pull request includes changes to rename the `KleverChain IDE` to `Klever Blockchain IDE` throughout the codebase and documentation. The main changes include updates to the `README.md`, `package.json`, and various TypeScript files to reflect the new name.

Documentation updates:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L1-R7): Updated all instances of `KleverChain IDE` to `Klever Blockchain IDE`, including descriptions, installation instructions, and settings configurations. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L1-R7) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L18-R18) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L30-R30) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L57-R64) [[5]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L82-R84) [[6]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L97-R97) [[7]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L106-R109) [[8]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L118-R130)

Configuration updates:

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L3-R5): Changed the `displayName` and `description` fields to use `Klever Blockchain IDE`. Updated the version number to `1.0.9`.

Code updates:

* [`src/extension.ts`](diffhunk://#diff-04bba6a35cad1c794cbbe677678a51de13441b7a6ee8592b7b50be1f05c6f626L15-R15): Updated activation and deactivation messages to reflect the new name. [[1]](diffhunk://#diff-04bba6a35cad1c794cbbe677678a51de13441b7a6ee8592b7b50be1f05c6f626L15-R15) [[2]](diffhunk://#diff-04bba6a35cad1c794cbbe677678a51de13441b7a6ee8592b7b50be1f05c6f626L68-R68)
* [`src/feedback.ts`](diffhunk://#diff-e6c8dab39e2dcea6882ed534980280aab6cd0598033b8291d1da771e7ce9fde7L47-R47): Changed the output channel name and error message details to `Klever Blockchain`. [[1]](diffhunk://#diff-e6c8dab39e2dcea6882ed534980280aab6cd0598033b8291d1da771e7ce9fde7L47-R47) [[2]](diffhunk://#diff-e6c8dab39e2dcea6882ed534980280aab6cd0598033b8291d1da771e7ce9fde7L59-R59)
* [`src/presenter.ts`](diffhunk://#diff-55646652688778950ee427e14056b68a66c991a95b5a2e71826c9d981b619ee1L36-R36): Updated prompts related to `ksc` and `koperator` installations to use `Klever Blockchain IDE`. [[1]](diffhunk://#diff-55646652688778950ee427e14056b68a66c991a95b5a2e71826c9d981b619ee1L36-R36) [[2]](diffhunk://#diff-55646652688778950ee427e14056b68a66c991a95b5a2e71826c9d981b619ee1L61-R61)